### PR TITLE
remove `SAFE_SLOTS_TO_UPDATE_JUSTIFIED`

### DIFF
--- a/chiado/config.yaml
+++ b/chiado/config.yaml
@@ -39,10 +39,6 @@ HYSTERESIS_QUOTIENT: 4
 HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 # 5 (plus 1.25)
 HYSTERESIS_UPWARD_MULTIPLIER: 5
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 # Validator
 # ---------------------------------------------------------------
 # 2**10 (= 1024) ~1.4 hour

--- a/devnets/gnosis-withdrawal-devnet-2/config.yaml
+++ b/devnets/gnosis-withdrawal-devnet-2/config.yaml
@@ -49,10 +49,6 @@ HYSTERESIS_QUOTIENT: 4
 HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 # 5 (plus 1.25)
 HYSTERESIS_UPWARD_MULTIPLIER: 5
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 # Validator
 # ---------------------------------------------------------------
 # 2**10 (= 1024) ~1.4 hour

--- a/devnets/gnosis-withdrawal-devnet-3/config.yaml
+++ b/devnets/gnosis-withdrawal-devnet-3/config.yaml
@@ -49,10 +49,6 @@ HYSTERESIS_QUOTIENT: 4
 HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 # 5 (plus 1.25)
 HYSTERESIS_UPWARD_MULTIPLIER: 5
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 # Validator
 # ---------------------------------------------------------------
 # 2**10 (= 1024) ~1.4 hour

--- a/devnets/gnosis-withdrawal-devnet-4/config.yaml
+++ b/devnets/gnosis-withdrawal-devnet-4/config.yaml
@@ -49,10 +49,6 @@ HYSTERESIS_QUOTIENT: 4
 HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 # 5 (plus 1.25)
 HYSTERESIS_UPWARD_MULTIPLIER: 5
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 # Validator
 # ---------------------------------------------------------------
 # 2**10 (= 1024) ~1.4 hour

--- a/mainnet/config.yaml
+++ b/mainnet/config.yaml
@@ -33,10 +33,6 @@ HYSTERESIS_QUOTIENT: 4
 HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 # 5 (plus 1.25)
 HYSTERESIS_UPWARD_MULTIPLIER: 5
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 # Validator
 # ---------------------------------------------------------------
 # 2**10 (= 1024) ~1.4 hour

--- a/presets/gnosis/phase0.yaml
+++ b/presets/gnosis/phase0.yaml
@@ -18,12 +18,6 @@ HYSTERESIS_DOWNWARD_MULTIPLIER: 1
 HYSTERESIS_UPWARD_MULTIPLIER: 5
 
 
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
-
-
 # Gwei values
 # ---------------------------------------------------------------
 # 2**0 * 10**9 (= 1,000,000,000) Gwei


### PR DESCRIPTION
The `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` constant is no longer used as the bouncing attack fix was removed:
https://github.com/ethereum/consensus-specs/pull/3290