### PR TITLE
Ensure config is synced

### DIFF
--- a/.github/workflows/sync_config.yaml
+++ b/.github/workflows/sync_config.yaml
@@ -1,0 +1,17 @@
+name: Update Config
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 */4 * * *'  # Runs every 4 hours
+
+jobs:
+  update-config:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Run Update Config Script
+      run: ./scripts/sync_config.sh

--- a/scripts/sync_config.sh
+++ b/scripts/sync_config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# URL of the YAML file to download
+YAML_URL="https://raw.githubusercontent.com/gnosischain/specs/master/consensus/config/gnosis.yaml"
+# Path to the local YAML file
+LOCAL_YAML_PATH="mainnet/config.yaml"
+
+# Download and replace the local YAML file
+curl -s -o "$LOCAL_YAML_PATH" "$YAML_URL"
+
+# Check for a git diff
+git diff --exit-code
+DIFF_STATUS=$?
+
+if [ $DIFF_STATUS -ne 0 ]; then
+    echo "Gnosis config is not synced."
+    exit 1
+else
+    echo "Gnosis config synced."
+fi
+


### PR DESCRIPTION
Every 4 hours and in each commit and pr, check that the config here reflects the config in specs main branch.

This strategy is not ideal, since CI can break for unrelated changes. However mantaining an updated config is an important time sensitive action that can be fixed easily. In the future we may have a more reliable strategy to sync the configs