### PR TITLE
Set correct CONFIG_NAME for chiado

### DIFF
--- a/chiado/config.yaml
+++ b/chiado/config.yaml
@@ -5,7 +5,7 @@ PRESET_BASE: 'gnosis'
 # * 'mainnet' - there can be only one
 # * 'prater' - testnet
 # Must match the regex: [a-z0-9\-]
-CONFIG_NAME: 'gnosis'
+CONFIG_NAME: 'chiado'
 
 # Transition
 # ---------------------------------------------------------------


### PR DESCRIPTION
Fix unwanted change in https://github.com/gnosischain/configs/pull/28 setting the CONFIG_NAME of chiado to gnosis